### PR TITLE
Add Docker development environment

### DIFF
--- a/build/custom.mk
+++ b/build/custom.mk
@@ -1,1 +1,5 @@
 # Include custom targets and environment variables here
+
+.PHONY: splunk
+splunk:
+	cd dev && docker-compose up

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,0 +1,3 @@
+FROM splunk/splunk
+
+RUN sudo mkdir scripts

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+    splunk:
+        build:
+            context: .
+        ports:
+            - "8000:8000"
+            - "8089:8089"
+        environment:
+            - SPLUNK_START_ARGS=--accept-license
+            - SPLUNK_PASSWORD=SplunkPass
+        volumes:
+            - ./scripts:/opt/splunk/bin/scripts

--- a/dev/splunk_scripts/test_script.sh
+++ b/dev/splunk_scripts/test_script.sh
@@ -1,0 +1,1 @@
+echo "This is the text script output"

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,17 @@ git clone https://github.com/owner/mattermost-plugin-splunk
 
 Note that this project uses [Go modules](https://github.com/golang/go/wiki/Modules). Be sure to locate the project outside of `$GOPATH`, or allow the use of Go modules within your `$GOPATH` with an `export GO111MODULE=on`.
 
+### Running a Splunk server with Docker
+
+There is a [docker-compose.yml](https://github.com/mattermost/mattermost-plugin-splunk/blob/master/dev/docker-compose.yml) in the `dev` folder of the repository, configured to run a Splunk server for development. You can run `make splunk` in the root of the repository to spin up the Splunk server. The Splunk web application will be served at http://localhost:8000.
+
+The `SPLUNK_PASSWORD` environment variable is set to `SplunkPass`, as defined in the `docker-compose.yml` file. You can login with these credentials:
+
+- Username: `admin`
+- Password: `SplunkPass`
+
+The files at [dev/splunk_scripts](https://github.com/mattermost/mattermost-plugin-splunk/tree/master/dev/splunk_scripts) are mapped as a volume on the `scripts` folder in the Docker container. Splunk is able to access the files in this folder, so feel free to add files to this folder on your computer for usage in Splunk.
+
 ### Building And Deployment
 
 To build your plugin use `make`


### PR DESCRIPTION
#### Summary

This PR adds a `docker-compose.yml` file to help spin up a Splunk server for development. The Splunk server can be spun up with the command `make splunk`, from the root of the repository.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-splunk/issues/50