### PR TITLE
Fix Login Auth calls

### DIFF
--- a/dev/default.yml
+++ b/dev/default.yml
@@ -1,0 +1,9 @@
+---
+splunk:
+  conf:
+    - key: alert_actions
+      value:
+        directory: /opt/splunk/etc/system/local
+        content:
+          default:
+            hostname: <MY_ALERT_HOSTNAME>

--- a/dev/default.yml
+++ b/dev/default.yml
@@ -6,4 +6,4 @@ splunk:
         directory: /opt/splunk/etc/system/local
         content:
           default:
-            hostname: <MY_ALERT_HOSTNAME>
+            hostname: <MY_ALERT_HOSTNAME>  # Example: https://XXXXX.ngrok.io

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -11,3 +11,5 @@ services:
             - SPLUNK_PASSWORD=SplunkPass
         volumes:
             - ./scripts:/opt/splunk/bin/scripts
+            # Splunk Ansible override configuration
+            - ./default.yml:/tmp/defaults/default.yml

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,14 +10,14 @@ Note that this project uses [Go modules](https://github.com/golang/go/wiki/Modul
 
 ### Running a Splunk server with Docker
 
-There is a [docker-compose.yml](https://github.com/mattermost/mattermost-plugin-splunk/blob/master/dev/docker-compose.yml) in the `dev` folder of the repository, configured to run a Splunk server for development. You can run `make splunk` in the root of the repository to spin up the Splunk server. The Splunk web application will be served at http://localhost:8000.
+There is a [docker-compose.yml](https://github.com/mattermost/mattermost-plugin-splunk/blob/master/dev/docker-compose.yml) in the `dev` folder of the repository, configured to run a Splunk server for development. You can run `make splunk` in the root of the repository to spin up the Splunk server. The Splunk web application will be served at `http://localhost:8000` and the API will be served at `https://localhost:8089`.
 
 The `SPLUNK_PASSWORD` environment variable is set to `SplunkPass`, as defined in the `docker-compose.yml` file. You can login with these credentials:
 
 - Username: `admin`
 - Password: `SplunkPass`
 
-The files at [dev/splunk_scripts](https://github.com/mattermost/mattermost-plugin-splunk/tree/master/dev/splunk_scripts) are mapped as a volume on the `scripts` folder in the Docker container. Splunk is able to access the files in this folder, so feel free to add files to this folder on your computer for usage in Splunk.
+If you want to modify the default Alert hostname, you can do so editing the `default.yml` file and replace `<MY_ALERT_HOSTNAME>` with your valid hostname (ex: `https://myhost.ngrok.io`).
 
 ### Building And Deployment
 

--- a/server/splunk/splunk.go
+++ b/server/splunk/splunk.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/mattermost/mattermost-plugin-splunk/server/store"
 
@@ -126,9 +127,10 @@ func (s *splunk) LoginUser(mattermostUserID string, server string, id string) er
 		s.currentUser = u
 		isNew = false
 	} else {
+		loginData := strings.Split(id, "/")
 		s.currentUser = store.SplunkUser{
 			Server: server,
-			Token:  id,
+			Token:  loginData[1],
 		}
 	}
 

--- a/server/splunk/splunk.go
+++ b/server/splunk/splunk.go
@@ -118,7 +118,7 @@ func (s *splunk) SyncUser(mattermostUserID string) error {
 }
 
 // LoginUser changes authorized user.
-// id is either username or token of user.
+// id is either username or username/token of user.
 func (s *splunk) LoginUser(mattermostUserID string, server string, id string) error {
 	var isNew = true
 
@@ -133,6 +133,10 @@ func (s *splunk) LoginUser(mattermostUserID string, server string, id string) er
 		s.currentUser = u
 		isNew = false
 	} else {
+		if token == "" {
+			return errors.New("The token is empty to authenticate a user")
+		}
+
 		s.currentUser = store.SplunkUser{
 			Server: server,
 			Token:  token,

--- a/server/splunk/splunk.go
+++ b/server/splunk/splunk.go
@@ -175,7 +175,7 @@ func newSplunk(api PluginAPI, st store.Store) *splunk {
 
 func extractUserInfo(id string) (string, string, error) {
 	if id == "" {
-		return "", "", errors.New("Arguments to extract username and/or token must be 2")
+		return "", "", errors.New("Please provide username and token like so: username/token. You can user username only if already authenticated")
 	}
 
 	loginData := strings.Split(id, "/")

--- a/server/splunk/splunk_test.go
+++ b/server/splunk/splunk_test.go
@@ -74,7 +74,7 @@ func Test_splunk_extractUserInfo(t *testing.T) {
 			id:           "",
 			username:     "",
 			token:        "",
-			errorMessage: "Arguments to extract username and/or token must be 2",
+			errorMessage: "Please provide username and token like so: username/token. You can user username only if already authenticated",
 		},
 		{
 			name:         "id has more than 2 parameters, return error",

--- a/server/splunk/splunk_test.go
+++ b/server/splunk/splunk_test.go
@@ -60,3 +60,55 @@ func Test_splunk_ChangeUser(t *testing.T) {
 		})
 	}
 }
+
+func Test_splunk_extractUserInfo(t *testing.T) {
+	tests := []struct {
+		name         string
+		id           string
+		username     string
+		token        string
+		errorMessage string
+	}{
+		{
+			name:         "id is empty, return error",
+			id:           "",
+			username:     "",
+			token:        "",
+			errorMessage: "Arguments to extract username and/or token must be 2",
+		},
+		{
+			name:         "id has more than 2 parameters, return error",
+			id:           "johndoe/token/more",
+			username:     "",
+			token:        "",
+			errorMessage: "Arguments to extract username and/or token must be 2",
+		},
+		{
+			name:         "id has only the username parameter, returns valid username",
+			id:           "johndoe",
+			username:     "johndoe",
+			token:        "",
+			errorMessage: "",
+		},
+		{
+			name:         "id has username and token parameters, returns username and token",
+			id:           "johndoe/token",
+			username:     "johndoe",
+			token:        "token",
+			errorMessage: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			username, token, err := extractUserInfo(tt.id)
+
+			if tt.errorMessage != "" {
+				assert.Equal(t, tt.errorMessage, err.Error())
+				return
+			}
+
+			assert.Equal(t, tt.username, username)
+			assert.Equal(t, tt.token, token)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

There was a bug when using the token, we were having the `username/token` as Auth header and only `token` was needed for all the calls. So I splitted the information coming from the slash command and store only the token in the token property of the user struct.

This closes #81 

<img width="551" alt="Screenshot 2023-01-19 at 09 58 51" src="https://user-images.githubusercontent.com/488556/213407141-d18e2b0c-5c10-4c6f-a5aa-ddf405c21458.png">

Keep in mind in order to test this we need to point to the Splunk API, by default `https://localhost:8089`, so with Ngrok we need to run `ngrok http --region=eu --hostname=XXXXXX.eu.ngrok.io https://localhost:8089`

[More information](https://github.com/mattermost/mattermost-plugin-splunk/pull/86#issuecomment-1387699878)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

